### PR TITLE
More small improvements

### DIFF
--- a/.changeset/cold-news-collect.md
+++ b/.changeset/cold-news-collect.md
@@ -1,0 +1,5 @@
+---
+'jats-convert': patch
+---
+
+Do not include footnote reference children in the tree

--- a/.changeset/short-poets-sing.md
+++ b/.changeset/short-poets-sing.md
@@ -1,0 +1,5 @@
+---
+'jats-fetch': patch
+---
+
+Rearrange PMC fetch order and improve download flow

--- a/.changeset/weak-houses-grab.md
+++ b/.changeset/weak-houses-grab.md
@@ -1,0 +1,5 @@
+---
+'jats-convert': patch
+---
+
+Remove redundant acknowledgments title

--- a/packages/jats-convert/src/index.ts
+++ b/packages/jats-convert/src/index.ts
@@ -370,7 +370,7 @@ const handlers: Record<string, Handler> = {
       }
       case RefType.fn:
       case RefType.tableFn: {
-        state.renderInline(node, 'footnoteReference', { label, identifier });
+        state.addLeaf('footnoteReference', { label, identifier });
         return;
       }
       default: {

--- a/packages/jats-convert/src/transforms/sections.yml
+++ b/packages/jats-convert/src/transforms/sections.yml
@@ -127,7 +127,7 @@ cases:
             - type: title
               children:
                 - type: text
-                  value: Acknowledgments
+                  value: My Ack
             - type: text
               value: My acknowledgments
     after:
@@ -149,7 +149,44 @@ cases:
               depth: 1
               children:
                 - type: text
+                  value: My Ack
+            - type: text
+              value: My acknowledgments
+  - title: Ack title removed if redundant
+    before:
+      type: root
+      children:
+        - type: sec
+          children:
+            - type: title
+              children:
+                - type: text
+                  value: My Title
+            - type: text
+              value: My content
+        - type: ack
+          children:
+            - type: title
+              children:
+                - type: text
                   value: Acknowledgments
+            - type: text
+              value: My acknowledgments
+    after:
+      type: root
+      children:
+        - type: block
+          children:
+            - type: heading
+              depth: 1
+              children:
+                - type: text
+                  value: My Title
+            - type: text
+              value: My content
+        - type: block
+          part: acknowledgments
+          children:
             - type: text
               value: My acknowledgments
   - title: Ack without title is treated as section

--- a/packages/jats-fetch/src/pubmed.ts
+++ b/packages/jats-fetch/src/pubmed.ts
@@ -282,6 +282,7 @@ export async function getPubMedJatsFromS3(
     session.log.debug(`Not available from open-access S3 bucket: ${pmcid}`);
     return { success: false, source: pmcid };
   } else {
+    session.log.debug(`Fetching PMC JATS from S3 bucket: ${pmcid}`);
     const result = await downloadFileFromS3(client, found.path, OA_CONFIG);
     return result;
   }


### PR DESCRIPTION
`jats-convert`
- Remove redundant "Acknowledgments" title if `part` is tagged as `acknowledgments`
- Do not keep footnote reference children

`jats-fetch`
- I found some flakiness with the `efetch` util, returning error XML. It is working again now, but this PR reorders and improves fallbacks for PMC downloads to reduce the impact of future flakiness.