### PR TITLE
Use OA api rather than listing file to locate tgz files

### DIFF
--- a/.changeset/happy-crabs-hope.md
+++ b/.changeset/happy-crabs-hope.md
@@ -1,0 +1,5 @@
+---
+'jats-fetch': patch
+---
+
+Use OA api rather than listing file to locate tgz files

--- a/package-lock.json
+++ b/package-lock.json
@@ -11780,7 +11780,8 @@
         "@aws-sdk/client-s3": "3.686.0",
         "doi-utils": "^2.0.0",
         "myst-cli-utils": "^2.0.11",
-        "node-fetch": "^3.3.1"
+        "node-fetch": "^3.3.1",
+        "xml-js": "^1.6.11"
       }
     },
     "packages/jats-tags": {

--- a/packages/jats-fetch/package.json
+++ b/packages/jats-fetch/package.json
@@ -38,6 +38,7 @@
     "@aws-sdk/client-s3": "3.686.0",
     "doi-utils": "^2.0.0",
     "node-fetch": "^3.3.1",
-    "myst-cli-utils": "^2.0.11"
+    "myst-cli-utils": "^2.0.11",
+    "xml-js": "^1.6.11"
   }
 }


### PR DESCRIPTION
This still may fall back to a listing file, if provided, but it will attempt to use the `oa` api utility provided by nih.

This also re-orderers the download function to (a) allow a `.tar.gz` url input and (2) try to download data first, if `--data` is requested.

I also refactored the ID convert functions and added another - pmc -> doi.