### PR TITLE
🪏 Extract better subject from jats

### DIFF
--- a/.changeset/yellow-donuts-behave.md
+++ b/.changeset/yellow-donuts-behave.md
@@ -1,0 +1,6 @@
+---
+'jats-convert': patch
+'jats-xml': patch
+---
+
+Extract better subject from jats

--- a/packages/jats-convert/tests/abstract-description.yml
+++ b/packages/jats-convert/tests/abstract-description.yml
@@ -1,0 +1,51 @@
+# frontmatter.description from JATS <abstract> (first two sentences). Loaded by convert.spec.ts.
+
+cases:
+  - title: sets description to first two sentences of abstract
+    jats: |-
+      <front>
+      <abstract><title>Abstract</title><p>First sentence here. Second sentence follows. Third sentence is extra.</p></abstract>
+      </front>
+      <body><p>Body.</p></body>
+    mdast:
+      type: block
+      data:
+        part: abstract
+    frontmatter:
+      description: First sentence here. Second sentence follows.
+
+  - title: short abstract uses full text as description
+    jats: |-
+      <front>
+      <abstract><p>Only one sentence.</p></abstract>
+      </front>
+      <body><p>x</p></body>
+    mdast:
+      type: block
+      data:
+        part: abstract
+    frontmatter:
+      description: Only one sentence.
+
+  - title: two-sentence abstract uses full text as description
+    jats: |-
+      <front>
+      <abstract><title>Abstract</title><p>Alpha one. Beta two.</p></abstract>
+      </front>
+      <body><p>x</p></body>
+    mdast:
+      type: block
+      data:
+        part: abstract
+    frontmatter:
+      description: Alpha one. Beta two.
+
+  - title: no abstract does not set description
+    jats: |-
+      <body><p>Body only.</p></body>
+    mdast:
+      type: paragraph
+      children:
+        - type: text
+          value: Body only.
+    expect_no_description: true

--- a/packages/jats-convert/tests/abstract.spec.ts
+++ b/packages/jats-convert/tests/abstract.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+import { descriptionFromAbstract } from '../src/transforms/abstract.js';
+
+describe('descriptionFromAbstract', () => {
+  test('returns first two sentences when more are present', () => {
+    const abstract = 'First sentence here. Second sentence follows. Third sentence is extra.';
+    expect(descriptionFromAbstract(abstract)).toBe('First sentence here. Second sentence follows.');
+  });
+
+  test('returns full text when only one sentence', () => {
+    expect(descriptionFromAbstract('Only one sentence.')).toBe('Only one sentence.');
+  });
+
+  test('returns full text when only two sentences', () => {
+    expect(descriptionFromAbstract('Alpha one. Beta two.')).toBe('Alpha one. Beta two.');
+  });
+
+  test('collapses whitespace', () => {
+    expect(descriptionFromAbstract('First one.\n\n  Second two.\nThird three.')).toBe(
+      'First one. Second two.',
+    );
+  });
+});

--- a/packages/jats-convert/tests/convert.spec.ts
+++ b/packages/jats-convert/tests/convert.spec.ts
@@ -11,6 +11,8 @@
  *   was read from a file or already contains `<back>`.
  * - `opts`: passed to jatsConvertTransform
  * - `mdast`: partial tree matched somewhere under the result. See helpers/mdastPartial.ts
+ * - `frontmatter`: optional partial frontmatter matched with expect(...).toMatchObject(...)
+ * - `expect_no_description`: when true, asserts `frontmatter.description` is undefined
  */
 import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
@@ -31,6 +33,8 @@ type ConvertYamlCase = {
   jats: string;
   jats_back?: string;
   mdast: unknown;
+  frontmatter?: Record<string, unknown>;
+  expect_no_description?: boolean;
   opts?: Options;
 };
 
@@ -62,7 +66,7 @@ describe('JATS → mdast (YAML fixtures)', () => {
     describe(file, () => {
       test.each(cases.map((c): [string, ConvertYamlCase] => [c.title, c]))('%s', (_, c) => {
         const xml = prepareJatsXmlForConvert(testsDir, c.jats, c.jats_back, c.title);
-        const { tree } = jatsConvertTransform(new Jats(xml), c.opts);
+        const { tree, frontmatter } = jatsConvertTransform(new Jats(xml), c.opts);
         expect(
           treeContainsPartial(tree, c.mdast),
           [
@@ -73,6 +77,12 @@ describe('JATS → mdast (YAML fixtures)', () => {
             `Actual tree: ${JSON.stringify(tree, null, 2)}`,
           ].join('\n'),
         ).toBe(true);
+        if (c.frontmatter !== undefined) {
+          expect(frontmatter).toMatchObject(c.frontmatter);
+        }
+        if (c.expect_no_description) {
+          expect(frontmatter.description).toBeUndefined();
+        }
       });
     });
   }

--- a/packages/jats-xml/src/jats.ts
+++ b/packages/jats-xml/src/jats.ts
@@ -149,7 +149,12 @@ export class Jats {
       return processAffiliation(aff);
     });
     const keywords = this.keywords?.map((k) => toText(k)) ?? [];
-    const firstSubject = select(Tags.subject, this.articleCategories ?? this.front);
+    const subjectScope = this.articleCategories ?? this.front;
+    const journalCollSubject = select(
+      `${Tags.subjGroup}[subj-group-type="hwp-journal-coll"] ${Tags.subject}`,
+      subjectScope,
+    );
+    const articleSubject = journalCollSubject ?? select(Tags.subject, subjectScope);
     const journalTitle = select(Tags.journalTitle, this.front);
     const license = this.license;
     let licenseString: string | null = null;
@@ -188,7 +193,7 @@ export class Jats {
         affiliations: affiliations.length ? affiliations : undefined,
         keywords: keywords.length ? keywords : undefined,
         venue: journalTitle ? { title: toText(journalTitle) } : undefined,
-        subject: firstSubject ? toText(firstSubject) : undefined,
+        subject: articleSubject ? toText(articleSubject) : undefined,
         license: licenseString ?? undefined,
         open_access: openAccess,
       },

--- a/packages/jats-xml/tests/frontmatter.yml
+++ b/packages/jats-xml/tests/frontmatter.yml
@@ -245,3 +245,33 @@ cases:
       affiliations:
         - id: aff2
           name: Department of Physiology, University of California San Francisco, San Francisco, California, United States of America
+  - title: <article-categories> prefers hwp-journal-coll subject over first
+    jats: |-
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.0 20120330//EN" "JATS-archivearticle1.dtd">
+      <article><front>
+      <article-categories>
+        <subj-group subj-group-type="author-type">
+          <subject>Regular Article</subject>
+        </subj-group>
+        <subj-group subj-group-type="heading">
+          <subject>New Results</subject>
+        </subj-group>
+        <subj-group subj-group-type="hwp-journal-coll">
+          <subject>Bioengineering</subject>
+        </subj-group>
+      </article-categories>
+      </front></article>
+    frontmatter:
+      subject: Bioengineering
+  - title: <article-categories> uses first subject when no hwp-journal-coll
+    jats: |-
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.0 20120330//EN" "JATS-archivearticle1.dtd">
+      <article><front>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>New Results</subject>
+        </subj-group>
+      </article-categories>
+      </front></article>
+    frontmatter:
+      subject: New Results


### PR DESCRIPTION
This looks for a specific tagged subject before falling back to first subject, when converting jats subject to myst frontmatter subject.