### PR TITLE
More bug fixes!

### DIFF
--- a/.changeset/four-parents-carry.md
+++ b/.changeset/four-parents-carry.md
@@ -1,0 +1,5 @@
+---
+'jats-xml': patch
+---
+
+Ignore malformed declaration

--- a/.changeset/silent-walls-invite.md
+++ b/.changeset/silent-walls-invite.md
@@ -1,0 +1,6 @@
+---
+'jats-convert': patch
+'jats-utils': patch
+---
+
+Handle 'position' JATS attribute and mdast property conflict

--- a/.changeset/weak-emus-sin.md
+++ b/.changeset/weak-emus-sin.md
@@ -1,0 +1,5 @@
+---
+'jats-convert': patch
+---
+
+Improve boxed-text title logic

--- a/packages/jats-convert/src/transforms/admonitions.spec.ts
+++ b/packages/jats-convert/src/transforms/admonitions.spec.ts
@@ -1,5 +1,6 @@
 import { VFile } from 'vfile';
 import { describe, expect, test } from 'vitest';
+import type { GenericParent } from 'myst-common';
 import { admonitionTransform } from './admonitions';
 
 describe('admonitionTransform', () => {
@@ -59,6 +60,33 @@ describe('admonitionTransform', () => {
     admonitionTransform(tree, vfile);
     expect(tree).toEqual(result);
   });
+  test('direct title is moved to admonition title', () => {
+    const vfile = new VFile();
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'boxed-text',
+          children: [
+            {
+              type: 'title',
+              children: [{ type: 'text', value: 'Direct title' }],
+            },
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'Box content' }],
+            },
+          ],
+        },
+      ],
+    };
+    admonitionTransform(tree, vfile);
+    expect(vfile.messages).toHaveLength(0);
+    expect((tree.children[0] as GenericParent).children?.[0]).toMatchObject({
+      type: 'admonitionTitle',
+      children: [{ type: 'text', value: 'Direct title' }],
+    });
+  });
   test('caption with no title is lost', () => {
     const vfile = new VFile();
     const tree = {
@@ -100,5 +128,89 @@ describe('admonitionTransform', () => {
     };
     admonitionTransform(tree, vfile);
     expect(tree).toEqual(result);
+  });
+  test('sec title is used when nested figure caption has no title', () => {
+    const vfile = new VFile();
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'boxed-text',
+          children: [
+            {
+              type: 'sec',
+              children: [
+                {
+                  type: 'label',
+                  children: [{ type: 'text', value: 'Box 1.' }],
+                },
+                {
+                  type: 'title',
+                  children: [{ type: 'text', value: 'Box title' }],
+                },
+                {
+                  type: 'p',
+                  children: [
+                    {
+                      type: 'fig',
+                      children: [
+                        {
+                          type: 'caption',
+                          children: [
+                            {
+                              type: 'p',
+                              children: [{ type: 'text', value: 'Figure caption' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    admonitionTransform(tree, vfile);
+    expect(vfile.messages).toHaveLength(0);
+    expect((tree.children[0] as GenericParent).children?.[0]?.children?.[1]).toMatchObject({
+      type: 'admonitionTitle',
+      children: [{ type: 'text', value: 'Box title' }],
+    });
+  });
+  test('sec heading is used when section transform already ran', () => {
+    const vfile = new VFile();
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'boxed-text',
+          children: [
+            {
+              type: 'sec',
+              children: [
+                {
+                  type: 'heading',
+                  depth: 1,
+                  children: [{ type: 'text', value: 'Section heading' }],
+                },
+                {
+                  type: 'p',
+                  children: [{ type: 'text', value: 'Box content' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    admonitionTransform(tree, vfile);
+    expect(vfile.messages).toHaveLength(0);
+    expect((tree.children[0] as GenericParent).children?.[0]?.children?.[0]).toMatchObject({
+      type: 'admonitionTitle',
+      children: [{ type: 'text', value: 'Section heading' }],
+    });
   });
 });

--- a/packages/jats-convert/src/transforms/admonitions.ts
+++ b/packages/jats-convert/src/transforms/admonitions.ts
@@ -6,6 +6,37 @@ import { remove } from 'unist-util-remove';
 import { Tags } from 'jats-tags';
 import type { VFile } from 'vfile';
 
+type BoxedTextTitle = {
+  title: GenericParent;
+  nodeToReplace: GenericParent;
+};
+
+/**
+ * Find the admonition title for a boxed-text.
+ */
+function findBoxedTextTitle(boxedText: GenericParent): BoxedTextTitle | undefined {
+  const directCaption = boxedText.children?.find((child) => child.type === Tags.caption) as
+    | GenericParent
+    | undefined;
+  if (directCaption) {
+    const title = select(Tags.title, directCaption) as GenericParent | undefined;
+    if (title) return { title, nodeToReplace: directCaption };
+  }
+
+  const directTitle = boxedText.children?.find((child) => child.type === Tags.title) as
+    | GenericParent
+    | undefined;
+  if (directTitle) return { title: directTitle, nodeToReplace: directTitle };
+
+  const secTitle = select(`${Tags.sec} > ${Tags.title}`, boxedText) as GenericParent | undefined;
+  if (secTitle) return { title: secTitle, nodeToReplace: secTitle };
+
+  const secHeading = select(`${Tags.sec} > heading`, boxedText) as GenericParent | undefined;
+  if (secHeading) return { title: secHeading, nodeToReplace: secHeading };
+
+  return undefined;
+}
+
 /**
  * Convert boxed-text caption to admonitionTitle (with content from caption > title)
  *
@@ -18,17 +49,14 @@ import type { VFile } from 'vfile';
 export function admonitionTransform(tree: GenericParent, file: VFile) {
   const boxedTexts = selectAll(Tags.boxedText, tree) as GenericParent[];
   boxedTexts.forEach((boxedText) => {
-    const caption = select(`${Tags.caption}`, boxedText) as GenericParent;
-    const title = caption
-      ? (select(Tags.title, caption) as GenericParent)
-      : (select(Tags.title, boxedText) as GenericParent);
-    if (!title) {
+    const found = findBoxedTextTitle(boxedText);
+    if (!found) {
       fileWarn(file, 'Encountered boxed-text without title', {
         node: boxedText,
         ruleId: RuleId.jatsParses,
       });
     } else {
-      const nodeToReplace = caption ?? title;
+      const { title, nodeToReplace } = found;
       nodeToReplace.type = 'admonitionTitle';
       nodeToReplace.children = title.children;
     }

--- a/packages/jats-convert/src/transforms/supplementary.ts
+++ b/packages/jats-convert/src/transforms/supplementary.ts
@@ -7,12 +7,12 @@ import { copyNode } from '../utils.js';
  * Move any supplementary-material marked as position=float to end of document
  */
 export function floatToEndTransform(body: Body) {
-  const floatSupplementaryMaterial = selectAll('supplementary-material[position=float]', body);
+  const floatSupplementaryMaterial = selectAll('supplementary-material[_position=float]', body);
   if (floatSupplementaryMaterial.length === 0) return;
   body.children?.push({ type: 'hr' });
   floatSupplementaryMaterial.forEach((node) => {
     const copy = copyNode(node);
-    delete copy.position;
+    delete copy._position;
     body?.children?.push(copy);
     node.type = '__delete__';
   });

--- a/packages/jats-utils/src/utils.ts
+++ b/packages/jats-utils/src/utils.ts
@@ -17,8 +17,10 @@ export function convertToUnist(
       const children = elements
         ?.map((el) => convertToUnist(el, { insidePreformat: nextInside }))
         .filter((n): n is GenericNode => !!n);
-      const { type, ...attrs } = attributes ?? {};
+      const { type, position, ...attrs } = attributes ?? {};
       if (type !== undefined) attrs._type = type;
+      // JATS layout position (e.g. float, anchor) must not use `position` — that is reserved for source locations in mdast.
+      if (position !== undefined) attrs._position = position;
       const next: GenericNode = { type: name ?? 'unknown', ...attrs };
       if (name === 'code') {
         next.value = elements?.[0].text as string;
@@ -82,8 +84,9 @@ export function convertToXml(node: GenericNode): Element {
       return { type: 'cdata', attributes, cdata };
     }
     default: {
-      const { children, _type, ...attributes } = rest;
+      const { children, _type, _position, ...attributes } = rest;
       if (_type !== undefined) attributes.type = _type;
+      if (_position !== undefined) attributes.position = _position;
       return { type: 'element', name: type, attributes, elements: children?.map(convertToXml) };
     }
   }

--- a/packages/jats-xml/src/jats.ts
+++ b/packages/jats-xml/src/jats.ts
@@ -77,6 +77,22 @@ function significantChildElements(elements: Element[] | undefined): Element[] | 
   });
 }
 
+/**
+ * Drop a leading processing instruction when it precedes doctype and the root element.
+ * Malformed prologs such as <?version xml="1.0"?> are parsed this way by xml-js.
+ */
+function dropLeadingPrologInstruction(elements: Element[] | undefined): Element[] | undefined {
+  if (
+    elements?.length === 3 &&
+    elements[0].type === 'instruction' &&
+    elements[1].type === 'doctype' &&
+    elements[2].type === 'element'
+  ) {
+    return elements.slice(1);
+  }
+  return elements;
+}
+
 export class Jats {
   declaration?: DeclarationAttributes;
   doctype?: string;
@@ -101,7 +117,7 @@ export class Jats {
     }
     const { declaration, elements } = this.raw;
     this.declaration = declaration?.attributes;
-    const filteredElements = significantChildElements(elements);
+    const filteredElements = dropLeadingPrologInstruction(significantChildElements(elements));
     if (filteredElements?.length && filteredElements[0].type !== 'doctype') {
       this.log?.warn('JATS is missing DOCTYPE declaration');
       filteredElements.unshift({ type: 'doctype' });

--- a/packages/jats-xml/tests/basic.spec.ts
+++ b/packages/jats-xml/tests/basic.spec.ts
@@ -227,3 +227,13 @@ describe('JATS XML attributes', () => {
     expect(roundTrip.attributes?.position).toBe('float');
   });
 });
+
+describe('JATS XML prolog', () => {
+  test('drops leading instruction before doctype and article', () => {
+    const data = `<?version xml="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20170631//EN" "JATS-archivearticle1.dtd">
+<article><front></front></article>`;
+    const jats = new Jats(data);
+    expect(jats.tree.type).toBe('article');
+  });
+});

--- a/packages/jats-xml/tests/basic.spec.ts
+++ b/packages/jats-xml/tests/basic.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from 'vitest';
 import fs from 'fs';
+import type { GenericNode } from 'myst-common';
 import { toText } from 'myst-common';
 import { select } from 'unist-util-select';
+import { xml2js } from 'xml-js';
+import type { Element } from 'xml-js';
 import { inferOptions, Jats } from '../src';
 import { Tags } from 'jats-tags';
-import { formatDate, toDate } from 'jats-utils';
+import { convertToUnist, convertToXml, formatDate, toDate } from 'jats-utils';
 import { processAffiliation, processContributor } from '../src/utils';
 
 describe('Basic JATS read', () => {
@@ -209,5 +212,18 @@ describe('Basic JATS read', () => {
 </article>`;
     const jats = new Jats(data);
     expect(jats.frontmatter.date).toEqual('2014-01-02');
+  });
+});
+
+describe('JATS XML attributes', () => {
+  test('position attribute is stored as _position to avoid mdast collision', () => {
+    const xml =
+      '<boxed-text id="box1" position="float"><sec><title>Box title</title></sec></boxed-text>';
+    const { elements } = xml2js(xml, { compact: false }) as Element;
+    const node = convertToUnist(elements![0]) as GenericNode;
+    expect(node.position).toBeUndefined();
+    expect(node._position).toBe('float');
+    const roundTrip = convertToXml(node);
+    expect(roundTrip.attributes?.position).toBe('float');
   });
 });


### PR DESCRIPTION
- Treat `position` like `type`: these are both JATS attributes and native mdast properties, so we need to store JATS `position` as `_position` so mdast utilities do not encounter type mismatch.
- Improve boxed-text title logic - there were edge cases where figures inside boxed-text broke title logic.
- Handle malformed declaration at the top.