### PR TITLE
🔢 Pull enumerators from figure/table ids/labels

### DIFF
--- a/.changeset/afraid-walls-drive.md
+++ b/.changeset/afraid-walls-drive.md
@@ -1,0 +1,5 @@
+---
+'jats-convert': patch
+---
+
+Pull enumerators from figure/table ids/labels

--- a/packages/jats-convert/src/enumerator.ts
+++ b/packages/jats-convert/src/enumerator.ts
@@ -1,0 +1,101 @@
+import type { GenericParent } from 'myst-common';
+import type { VFile } from 'vfile';
+import { selectAll } from 'unist-util-select';
+import { jatsFileWarn } from './messages.js';
+
+export type EnumeratorKind = 'figure' | 'table';
+
+const FIGURE_ID_PREFIX = /^fig/i;
+const TABLE_ID_PREFIX = /^(?:tbl|table|tab)/i;
+
+const FIGURE_LABEL_PREFIX = /^(?:figure|fig\.?)\s+/i;
+const TABLE_LABEL_PREFIX = /^(?:table|tbl\.?)\s+/i;
+
+/** Normalize a raw enumerator fragment for comparison and output. */
+export function normalizeEnumerator(value: string): string | undefined {
+  const normalized = value
+    .trim()
+    .replace(/[''""]+/g, '')
+    .replace(/[.,;:]+$/g, '')
+    .trim()
+    .toUpperCase();
+  return normalized || undefined;
+}
+
+function stripIdPrefix(id: string, kind: EnumeratorKind): string | undefined {
+  const trimmed = id.trim();
+  if (!trimmed) return undefined;
+  const prefix = kind === 'figure' ? FIGURE_ID_PREFIX : TABLE_ID_PREFIX;
+  if (!prefix.test(trimmed)) return undefined;
+  const rest = trimmed
+    .replace(prefix, '')
+    .replace(/^[-_.]+/, '')
+    .trim();
+  return rest || undefined;
+}
+
+function stripLabelPrefix(label: string, kind: EnumeratorKind): string | undefined {
+  const trimmed = label.trim();
+  if (!trimmed) return undefined;
+  const prefix = kind === 'figure' ? FIGURE_LABEL_PREFIX : TABLE_LABEL_PREFIX;
+  const rest = trimmed.replace(prefix, '').trim();
+  return rest || undefined;
+}
+
+export function enumeratorFromId(id: string, kind: EnumeratorKind): string | undefined {
+  const rest = stripIdPrefix(id, kind);
+  return rest ? normalizeEnumerator(rest) : undefined;
+}
+
+export function enumeratorFromLabel(label: string, kind: EnumeratorKind): string | undefined {
+  const rest = stripLabelPrefix(label, kind);
+  return rest ? normalizeEnumerator(rest) : undefined;
+}
+
+export function resolveEnumerator(opts: {
+  id?: string;
+  labelText?: string;
+  kind: EnumeratorKind;
+  source: string;
+  file?: VFile;
+}): string | undefined {
+  const fromId = opts.id ? enumeratorFromId(opts.id, opts.kind) : undefined;
+  const fromLabel = opts.labelText ? enumeratorFromLabel(opts.labelText, opts.kind) : undefined;
+
+  if (fromId && fromLabel && fromId !== fromLabel) {
+    jatsFileWarn(opts.file, 'Container id and label enumerators do not match', {
+      source: opts.source,
+      note: [
+        `id-enumerator=${fromId}`,
+        `label-enumerator=${fromLabel}`,
+        opts.id ? `id=${opts.id}` : undefined,
+        opts.labelText ? `label=${opts.labelText}` : undefined,
+      ]
+        .filter(Boolean)
+        .join('; '),
+    });
+    return fromLabel;
+  }
+
+  return fromLabel ?? fromId;
+}
+
+function hasEnumerator(node: GenericParent): boolean {
+  return typeof node.enumerator === 'string' && node.enumerator.length > 0;
+}
+
+/** Warn when some but not all containers of a kind have an enumerator. */
+export function warnMixedContainerEnumerators(tree: GenericParent, file?: VFile) {
+  for (const kind of ['figure', 'table'] as const) {
+    const containers = selectAll(`container[kind=${kind}]`, tree) as GenericParent[];
+    if (containers.length < 2) continue;
+    const enumerated = containers.filter(hasEnumerator).length;
+    const nonEnumerated = containers.length - enumerated;
+    if (enumerated > 0 && nonEnumerated > 0) {
+      jatsFileWarn(file, `Mix of enumerated and non-enumerated ${kind}s`, {
+        source: 'jats-convert:enumerator',
+        note: `enumerated=${enumerated}; non-enumerated=${nonEnumerated}`,
+      });
+    }
+  }
+}

--- a/packages/jats-convert/src/index.ts
+++ b/packages/jats-convert/src/index.ts
@@ -39,6 +39,7 @@ import {
 import { floatToEndTransform } from './transforms/supplementary.js';
 import { dataAvailabilityTransform } from './transforms/parts.js';
 import { abbreviationsFromTree } from './myst/abbreviations.js';
+import { resolveEnumerator, warnMixedContainerEnumerators } from './enumerator.js';
 
 const MEDIA_FIGURE_EXTENSIONS = [
   '.png',
@@ -225,6 +226,7 @@ const handlers: Record<string, Handler> = {
   fig(node, state) {
     const caption = select('caption', node) as GenericNode;
     const graphic = select('graphic,media', node) as GenericNode;
+    const labelNode = select('label', node) as GenericNode | undefined;
     const directTitle = node.children?.find((child) => child.type === 'title') as
       | GenericNode
       | undefined;
@@ -233,7 +235,14 @@ const handlers: Record<string, Handler> = {
       : undefined;
     const title = directTitle ?? captionTitle;
     const { label, identifier } = normalizeLabel(node.id) ?? {};
-    state.openNode('container', { label, identifier, kind: 'figure' });
+    const enumerator = resolveEnumerator({
+      id: node.id,
+      labelText: labelNode ? toText(labelNode) : undefined,
+      kind: 'figure',
+      source: 'fig',
+      file: state.file,
+    });
+    state.openNode('container', { label, identifier, kind: 'figure', enumerator });
     const wasInContainer = state.data.isInContainer;
     state.data.isInContainer = true;
     const link = graphic?.['xlink:href'];
@@ -268,7 +277,14 @@ const handlers: Record<string, Handler> = {
     const labelNode = select('label', node) as GenericNode | undefined;
     const titleNode = select('title', node) as GenericNode | undefined;
     const { label, identifier } = normalizeLabel(node.id) ?? {};
-    state.openNode('container', { label, identifier, kind: 'table' });
+    const enumerator = resolveEnumerator({
+      id: node.id,
+      labelText: labelNode ? toText(labelNode) : undefined,
+      kind: 'table',
+      source: 'table-wrap',
+      file: state.file,
+    });
+    state.openNode('container', { label, identifier, kind: 'table', enumerator });
     const wasInContainer = state.data.isInContainer;
     state.data.isInContainer = true;
     state.openNode('caption');
@@ -456,7 +472,15 @@ const handlers: Record<string, Handler> = {
     }
     if (url && MEDIA_FIGURE_EXTENSIONS.find((ext) => url.endsWith(ext))) {
       const title = select('title', media) as GenericNode | undefined;
-      state.openNode('container', { label, identifier, kind: 'figure' });
+      const labelElement = select('label', node) as GenericNode | undefined;
+      const enumerator = resolveEnumerator({
+        id: node.id,
+        labelText: labelElement ? toText(labelElement) : undefined,
+        kind: 'figure',
+        source: 'supplementary-material',
+        file: state.file,
+      });
+      state.openNode('container', { label, identifier, kind: 'figure', enumerator });
       const wasInContainer = state.data.isInContainer;
       state.data.isInContainer = true;
       state.addLeaf('image', { url });
@@ -686,6 +710,7 @@ export const jatsConvertPlugin: Plugin<[Jats, Options?], Body, Body> = function 
     abbreviationFootnoteTransform(tree, frontmatter, file);
     abbreviationsFromTree(tree, frontmatter);
     tableFootnotesToLegend(tree, file);
+    warnMixedContainerEnumerators(tree, file);
     const abstract = selectAll('block', tree).find((block) => {
       return block.data && (block.data as any).part === 'abstract';
     });

--- a/packages/jats-convert/tests/convert.spec.ts
+++ b/packages/jats-convert/tests/convert.spec.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import { Jats } from 'jats-xml';
+import { VFile } from 'vfile';
 import type { Options } from '../src/types';
 import { jatsConvertTransform } from '../src';
 import { prepareJatsXmlForConvert } from './helpers/wrapJatsSnippet';
@@ -37,12 +38,14 @@ import mathYml from './math.yml' with { type: 'text' };
 import preformatYml from './preformat.yml' with { type: 'text' };
 import referencesYml from './references.yml' with { type: 'text' };
 import tablesYml from './tables.yml' with { type: 'text' };
+import enumeratorsYml from './enumerators.yml' with { type: 'text' };
 
 const YAML_FIXTURES: Record<string, string> = {
   'abstract-description.yml': abstractDescriptionYml,
   'basic.yml': basicYml,
   'boxedtext.yml': boxedtextYml,
   'figures.yml': figuresYml,
+  'enumerators.yml': enumeratorsYml,
   'images.yml': imagesYml,
   'math.yml': mathYml,
   'preformat.yml': preformatYml,
@@ -60,6 +63,8 @@ type ConvertYamlCase = {
   mdast: unknown;
   frontmatter?: Record<string, unknown>;
   expect_no_description?: boolean;
+  expect_warn_contains?: string[];
+  expect_no_warn_contains?: string[];
   opts?: Options;
 };
 
@@ -93,7 +98,9 @@ describe('JATS → mdast (YAML fixtures)', () => {
     describe(file, () => {
       test.each(cases.map((c): [string, ConvertYamlCase] => [c.title, c]))('%s', (_, c) => {
         const xml = prepareJatsXmlForConvert(testsDir, c.jats, c.jats_back, c.title);
-        const { tree, frontmatter } = jatsConvertTransform(new Jats(xml), c.opts);
+        const vfile = c.opts?.vfile ?? new VFile();
+        const opts = { ...c.opts, vfile };
+        const { tree, frontmatter } = jatsConvertTransform(new Jats(xml), opts);
         expect(
           treeContainsPartial(tree, c.mdast),
           [
@@ -109,6 +116,28 @@ describe('JATS → mdast (YAML fixtures)', () => {
         }
         if (c.expect_no_description) {
           expect(frontmatter.description).toBeUndefined();
+        }
+        if (c.expect_warn_contains?.length) {
+          const reasons = vfile.messages
+            .filter((m) => m.fatal === false)
+            .map((m) => m.reason ?? '');
+          for (const fragment of c.expect_warn_contains) {
+            expect(
+              reasons.some((r) => r.includes(fragment)),
+              `Expected warning containing "${fragment}"; got: ${reasons.join(' | ') || '(none)'}`,
+            ).toBe(true);
+          }
+        }
+        if (c.expect_no_warn_contains?.length) {
+          const reasons = vfile.messages
+            .filter((m) => m.fatal === false)
+            .map((m) => m.reason ?? '');
+          for (const fragment of c.expect_no_warn_contains) {
+            expect(
+              reasons.some((r) => r.includes(fragment)),
+              `Expected no warning containing "${fragment}"; got: ${reasons.join(' | ') || '(none)'}`,
+            ).toBe(false);
+          }
         }
       });
     });

--- a/packages/jats-convert/tests/enumerators.yml
+++ b/packages/jats-convert/tests/enumerators.yml
@@ -1,0 +1,202 @@
+cases:
+  - source: fig-id-and-label-match
+    title: figure id and label yield matching enumerator
+    jats: |-
+      <fig id="figs1" position="float">
+        <label>Figure S1</label>
+        <caption><p>Supplementary figure.</p></caption>
+        <graphic xlink:href="fig-s1.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      identifier: figs1
+      enumerator: S1
+
+  - source: fig-id-only
+    title: figure id alone yields enumerator when label is absent
+    jats: |-
+      <fig id="fig2" position="float">
+        <caption><p>Second figure.</p></caption>
+        <graphic xlink:href="fig2.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      identifier: fig2
+      enumerator: '2'
+
+  - source: fig-label-only
+    title: figure label alone yields enumerator when id is absent
+    jats: |-
+      <fig position="float">
+        <label>Fig. 3</label>
+        <caption><p>Third figure.</p></caption>
+        <graphic xlink:href="fig3.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: '3'
+
+  - source: fig-label-fig-prefix
+    title: figure label with Fig prefix is normalized to caps
+    jats: |-
+      <fig id="fig4a" position="float">
+        <label>Fig 4A</label>
+        <caption><p>Panel figure.</p></caption>
+        <graphic xlink:href="fig4a.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: 4A
+
+  - source: fig-label-trailing-period
+    title: trailing punctuation on label is stripped from enumerator
+    jats: |-
+      <fig id="fig1" position="float">
+        <label>Figure 1.</label>
+        <caption><p>Main figure.</p></caption>
+        <graphic xlink:href="fig1.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: '1'
+
+  - source: table-wrap-id-and-label
+    title: table id and label yield matching enumerator
+    jats: |-
+      <table-wrap id="tbl2">
+        <label>Table 2</label>
+        <table>
+          <tbody><tr><td>cell</td></tr></tbody>
+        </table>
+      </table-wrap>
+    mdast:
+      type: container
+      kind: table
+      identifier: tbl2
+      enumerator: '2'
+
+  - source: table-wrap-label-table-prefix
+    title: table label with Table prefix is normalized
+    jats: |-
+      <table-wrap id="table1">
+        <label>Table 1.</label>
+        <table>
+          <tbody><tr><td>cell</td></tr></tbody>
+        </table>
+      </table-wrap>
+    mdast:
+      type: container
+      kind: table
+      enumerator: '1'
+
+  - source: fig-id-label-mismatch
+    title: mismatched id and label prefer label enumerator and warn
+    jats: |-
+      <fig id="fig1" position="float">
+        <label>Figure 2</label>
+        <caption><p>Mismatched labels.</p></caption>
+        <graphic xlink:href="fig.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: '2'
+    expect_warn_contains:
+      - Container id and label enumerators do not match
+
+  - source: fig-mixed-enumeration
+    title: mix of enumerated and non-enumerated figures warns once
+    jats: |-
+      <fig id="fig1" position="float">
+        <label>Figure 1</label>
+        <caption><p>Enumerated figure.</p></caption>
+        <graphic xlink:href="fig1.png"/>
+      </fig>
+      <fig id="pclm.0000068.g001" position="float">
+        <caption><p>Non-standard id, no label.</p></caption>
+        <graphic xlink:href="fig2.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: '1'
+    expect_warn_contains:
+      - Mix of enumerated and non-enumerated figures
+
+  - source: fig-all-enumerated
+    title: all figures enumerated does not warn about mixed enumeration
+    jats: |-
+      <fig id="fig1" position="float">
+        <label>Figure 1</label>
+        <caption><p>First.</p></caption>
+        <graphic xlink:href="fig1.png"/>
+      </fig>
+      <fig id="fig2" position="float">
+        <label>Figure 2</label>
+        <caption><p>Second.</p></caption>
+        <graphic xlink:href="fig2.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: '2'
+    expect_no_warn_contains:
+      - Mix of enumerated and non-enumerated figures
+
+  - source: fig-none-enumerated
+    title: no figure enumerators does not warn about mixed enumeration
+    jats: |-
+      <fig id="pclm.0000068.g001" position="float">
+        <caption><p>First.</p></caption>
+        <graphic xlink:href="fig1.png"/>
+      </fig>
+      <fig id="pclm.0000068.g002" position="float">
+        <caption><p>Second.</p></caption>
+        <graphic xlink:href="fig2.png"/>
+      </fig>
+    mdast:
+      type: container
+      kind: figure
+    expect_no_warn_contains:
+      - Mix of enumerated and non-enumerated figures
+
+  - source: table-mixed-enumeration
+    title: mix of enumerated and non-enumerated tables warns once
+    jats: |-
+      <table-wrap id="tbl1">
+        <label>Table 1</label>
+        <table><tbody><tr><td>a</td></tr></tbody></table>
+      </table-wrap>
+      <table-wrap id="custom-table-id">
+        <table><tbody><tr><td>b</td></tr></tbody></table>
+      </table-wrap>
+    mdast:
+      type: container
+      kind: table
+      enumerator: '1'
+    expect_warn_contains:
+      - Mix of enumerated and non-enumerated tables
+
+  - source: figures-enumerated-tables-not
+    title: all figures enumerated and all tables non-enumerated is fine
+    jats: |-
+      <fig id="fig1" position="float">
+        <label>Figure 1</label>
+        <caption><p>Figure.</p></caption>
+        <graphic xlink:href="fig1.png"/>
+      </fig>
+      <table-wrap id="custom-table-id">
+        <table><tbody><tr><td>cell</td></tr></tbody></table>
+      </table-wrap>
+    mdast:
+      type: container
+      kind: figure
+      enumerator: '1'
+    expect_no_warn_contains:
+      - Mix of enumerated and non-enumerated figures
+      - Mix of enumerated and non-enumerated tables


### PR DESCRIPTION
This attempts to parse figure/table enumerators from `fig.id` attribute, e.g. `id=figs1` -> `enumerator: S1`, and from figure `<label>` elements, e.g. `<label>Fig. S1</label>` -> `enumerator: S1`.

It warns if the "id" enumerator and the "label" enumerator are both present but do not match. It also warns if some figures get enumerators and some do not.

This PR does not cover `math` enumerators.