### PR TITLE
🗃️ Add custom handling for supplementary files

### DIFF
--- a/.changeset/shy-days-exist.md
+++ b/.changeset/shy-days-exist.md
@@ -1,0 +1,8 @@
+---
+'jats-convert': patch
+---
+
+Add custom handling for supplementary files
+
+Previously, supplementary "media" nodes were treated as "generic children" if they were not known image types.
+Now they are recognized and supported as download links without warnings.

--- a/packages/jats-convert/src/index.ts
+++ b/packages/jats-convert/src/index.ts
@@ -40,21 +40,13 @@ import { floatToEndTransform } from './transforms/supplementary.js';
 import { dataAvailabilityTransform } from './transforms/parts.js';
 import { abbreviationsFromTree } from './myst/abbreviations.js';
 import { resolveEnumerator, warnMixedContainerEnumerators } from './enumerator.js';
-
-const MEDIA_FIGURE_EXTENSIONS = [
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.svg',
-  '.gif',
-  '.tiff',
-  '.tif',
-  '.eps',
-  '.webp',
-  '.mp4',
-  '.mov',
-  '.avi',
-];
+import {
+  captionFromSupplementary,
+  isFigureMediaUrl,
+  mimeTypeFromMedia,
+  supplementaryFileLinkLabel,
+  unhandledSupplementaryChildTypes,
+} from './supplementary.js';
 
 function refTypeToReferenceKind(kind?: RefType): string | undefined {
   switch (kind) {
@@ -453,24 +445,21 @@ const handlers: Record<string, Handler> = {
   },
   ['supplementary-material'](node, state) {
     const { label, identifier } = normalizeLabel(node.id) ?? {};
-    let maybeCaption: GenericNode | undefined;
-    let media: GenericNode | undefined;
-    if (node.children?.length === 1 && node.children[0].type === 'media') {
-      media = node.children[0];
-    } else if (
-      node.children?.length === 2 &&
-      node.children[0].type === 'label' &&
-      node.children[1].type === 'media'
-    ) {
-      maybeCaption = node.children[0];
-      media = node.children[1];
-    }
-    const url = media?.['xlink:href'];
-    let caption = (select('caption', media) ?? maybeCaption) as GenericNode | undefined;
-    if (caption?.children?.length === 1 && caption.children[0].type === 'p') {
-      caption = caption.children[0];
-    }
-    if (url && MEDIA_FIGURE_EXTENSIONS.find((ext) => url.endsWith(ext))) {
+    const mediaNodes = selectAll('media', node) as GenericNode[];
+    const figureMedia = mediaNodes.filter((media) => isFigureMediaUrl(media['xlink:href']));
+    const fileMedia = mediaNodes.filter(
+      (media) => media['xlink:href'] && !isFigureMediaUrl(media['xlink:href']),
+    );
+
+    const renderMediaFigure = (media: GenericNode) => {
+      const url = media['xlink:href'];
+      if (!url) {
+        state.warn('Supplementary-material media without xlink:href', 'supplementary-material', {
+          note: node.id ? `id=${node.id}` : undefined,
+        });
+        return;
+      }
+      const caption = captionFromSupplementary(node, media);
       const title = select('title', media) as GenericNode | undefined;
       const labelElement = select('label', node) as GenericNode | undefined;
       const enumerator = resolveEnumerator({
@@ -501,25 +490,86 @@ const handlers: Record<string, Handler> = {
       state.closeNode();
       state.closeNode();
       state.data.isInContainer = wasInContainer;
-    } else {
-      let detail: string;
-      if (!media) {
-        detail = 'missing expected media child';
-      } else if (!url) {
-        detail = 'media without xlink:href';
-      } else {
-        detail = `url not a figure media extension: ${url}`;
+    };
+
+    const renderMediaFiles = (media: GenericNode[]) => {
+      const withUrl = media.filter((item) => item['xlink:href']);
+      if (withUrl.length === 0) return;
+      if (withUrl.length > 1) {
+        state.openNode('list', { ordered: true });
       }
-      state.warn('Supplementary-material rendered as generic content', 'supplementary-material', {
-        note: node.id ? `id=${node.id} ${detail}` : detail,
+      withUrl.forEach((item, index) => {
+        const url = item['xlink:href'] as string;
+        const contentType = mimeTypeFromMedia(item);
+        if (withUrl.length > 1) {
+          state.openNode('listItem');
+        }
+        state.openNode('paragraph');
+        state.openNode('link', {
+          url,
+          static: true,
+          data: contentType ? { contentType } : undefined,
+        });
+        state.text(supplementaryFileLinkLabel(index, item, url));
+        state.closeNode();
+        state.closeNode();
+        if (withUrl.length > 1) {
+          state.closeNode();
+        }
       });
+      if (withUrl.length > 1) {
+        state.closeNode();
+      }
+    };
+
+    const warnUnhandledSupplementaryChildren = () => {
+      const types = unhandledSupplementaryChildTypes(node);
+      if (types.length === 0) return;
+      state.warn(
+        'Supplementary-material has unhandled child content alongside media',
+        'supplementary-material',
+        {
+          note: node.id
+            ? `id=${node.id} types=${types.join(', ')}`
+            : `types=${types.join(', ')}`,
+        },
+      );
+    };
+
+    if (figureMedia.length === 1 && fileMedia.length === 0) {
+      renderMediaFigure(figureMedia[0]!);
+      warnUnhandledSupplementaryChildren();
+      return;
+    }
+
+    if (fileMedia.length > 0 || figureMedia.length > 1) {
       if (node.id) {
         state.openNode('div', { label, identifier });
       }
-      state.renderChildren(node);
+      figureMedia.forEach((media) => renderMediaFigure(media));
+      renderMediaFiles(fileMedia);
       if (node.id) {
         state.closeNode();
       }
+      warnUnhandledSupplementaryChildren();
+      return;
+    }
+
+    let detail: string;
+    if (mediaNodes.length === 0) {
+      detail = 'missing media children';
+    } else {
+      detail = 'media without xlink:href';
+    }
+    state.warn('Supplementary-material rendered as generic content', 'supplementary-material', {
+      note: node.id ? `id=${node.id} ${detail}` : detail,
+    });
+    if (node.id) {
+      state.openNode('div', { label, identifier });
+    }
+    state.renderChildren(node);
+    if (node.id) {
+      state.closeNode();
     }
   },
   ['app-group'](node, state) {

--- a/packages/jats-convert/src/index.ts
+++ b/packages/jats-convert/src/index.ts
@@ -496,7 +496,7 @@ const handlers: Record<string, Handler> = {
       const withUrl = media.filter((item) => item['xlink:href']);
       if (withUrl.length === 0) return;
       if (withUrl.length > 1) {
-        state.openNode('list', { ordered: true });
+        state.openNode('list', { ordered: false });
       }
       withUrl.forEach((item, index) => {
         const url = item['xlink:href'] as string;

--- a/packages/jats-convert/src/index.ts
+++ b/packages/jats-convert/src/index.ts
@@ -529,9 +529,7 @@ const handlers: Record<string, Handler> = {
         'Supplementary-material has unhandled child content alongside media',
         'supplementary-material',
         {
-          note: node.id
-            ? `id=${node.id} types=${types.join(', ')}`
-            : `types=${types.join(', ')}`,
+          note: node.id ? `id=${node.id} types=${types.join(', ')}` : `types=${types.join(', ')}`,
         },
       );
     };
@@ -546,7 +544,9 @@ const handlers: Record<string, Handler> = {
       if (node.id) {
         state.openNode('div', { label, identifier });
       }
-      figureMedia.forEach((media) => renderMediaFigure(media));
+      figureMedia.forEach((media) => {
+        renderMediaFigure(media);
+      });
       renderMediaFiles(fileMedia);
       if (node.id) {
         state.closeNode();

--- a/packages/jats-convert/src/index.ts
+++ b/packages/jats-convert/src/index.ts
@@ -495,10 +495,13 @@ const handlers: Record<string, Handler> = {
     const renderMediaFiles = (media: GenericNode[]) => {
       const withUrl = media.filter((item) => item['xlink:href']);
       if (withUrl.length === 0) return;
+      const labelElement = select('label', node) as GenericNode | undefined;
+      const groupLabel = labelElement ? toText(labelElement) : undefined;
+      const singleFile = withUrl.length === 1;
       if (withUrl.length > 1) {
         state.openNode('list', { ordered: false });
       }
-      withUrl.forEach((item, index) => {
+      withUrl.forEach((item) => {
         const url = item['xlink:href'] as string;
         const contentType = mimeTypeFromMedia(item);
         if (withUrl.length > 1) {
@@ -510,7 +513,7 @@ const handlers: Record<string, Handler> = {
           static: true,
           data: contentType ? { contentType } : undefined,
         });
-        state.text(supplementaryFileLinkLabel(index, item, url));
+        state.text(supplementaryFileLinkLabel({ media: item, url, groupLabel, singleFile }));
         state.closeNode();
         state.closeNode();
         if (withUrl.length > 1) {

--- a/packages/jats-convert/src/supplementary.ts
+++ b/packages/jats-convert/src/supplementary.ts
@@ -1,5 +1,5 @@
 import type { GenericNode } from 'myst-common';
-import { select, selectAll } from 'unist-util-select';
+import { select } from 'unist-util-select';
 
 export const MEDIA_FIGURE_EXTENSIONS = [
   '.png',
@@ -56,8 +56,17 @@ export function fileTypeLabel(media: GenericNode, url: string): string {
   return 'file';
 }
 
-export function supplementaryFileLinkLabel(index: number, media: GenericNode, url: string): string {
-  return `Supplementary File ${index + 1} (${fileTypeLabel(media, url)})`;
+export function supplementaryFileLinkLabel(opts: {
+  media: GenericNode;
+  url: string;
+  groupLabel?: string;
+  singleFile?: boolean;
+}): string {
+  const { media, url, groupLabel, singleFile } = opts;
+  if (singleFile && groupLabel?.trim()) {
+    return groupLabel.trim();
+  }
+  return `Supplementary file (${fileTypeLabel(media, url)})`;
 }
 
 export function captionFromSupplementary(

--- a/packages/jats-convert/src/supplementary.ts
+++ b/packages/jats-convert/src/supplementary.ts
@@ -1,0 +1,84 @@
+import type { GenericNode } from 'myst-common';
+import { select, selectAll } from 'unist-util-select';
+
+export const MEDIA_FIGURE_EXTENSIONS = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.svg',
+  '.gif',
+  '.tiff',
+  '.tif',
+  '.eps',
+  '.webp',
+  '.mp4',
+  '.mov',
+  '.avi',
+];
+
+export function isFigureMediaUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  return MEDIA_FIGURE_EXTENSIONS.some((ext) => url.toLowerCase().endsWith(ext));
+}
+
+export function mimeTypeFromMedia(media: GenericNode): string | undefined {
+  const type = media.mimetype;
+  const subtype = media['mime-subtype'];
+  if (typeof type === 'string' && typeof subtype === 'string' && type && subtype) {
+    return `${type}/${subtype}`;
+  }
+  return undefined;
+}
+
+const MIME_SUBTYPE_LABELS: Record<string, string> = {
+  pdf: 'pdf',
+  'vnd.ms-excel': 'xls',
+  'vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'vnd.ms-powerpoint': 'ppt',
+  'vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+  'vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  msword: 'doc',
+  zip: 'zip',
+  'x-zip-compressed': 'zip',
+  json: 'json',
+  xml: 'xml',
+  csv: 'csv',
+  plain: 'txt',
+};
+
+export function fileTypeLabel(media: GenericNode, url: string): string {
+  const subtype = media['mime-subtype'];
+  if (typeof subtype === 'string' && MIME_SUBTYPE_LABELS[subtype]) {
+    return MIME_SUBTYPE_LABELS[subtype];
+  }
+  const ext = url.split(/[?#]/)[0]?.split('.').pop()?.toLowerCase();
+  if (ext) return ext;
+  return 'file';
+}
+
+export function supplementaryFileLinkLabel(index: number, media: GenericNode, url: string): string {
+  return `Supplementary File ${index + 1} (${fileTypeLabel(media, url)})`;
+}
+
+export function captionFromSupplementary(
+  node: GenericNode,
+  media?: GenericNode,
+): GenericNode | undefined {
+  const labelElement = select('label', node) as GenericNode | undefined;
+  let caption = (select('caption', media) ?? labelElement) as GenericNode | undefined;
+  if (caption?.children?.length === 1 && caption.children[0].type === 'p') {
+    caption = caption.children[0];
+  }
+  return caption;
+}
+
+/** Direct children handled implicitly when rendering media (not rendered separately). */
+const SUPPLEMENTARY_HANDLED_CHILD_TYPES = new Set(['media', 'label']);
+
+/** Child element types on supplementary-material that are not converted alongside media. */
+export function unhandledSupplementaryChildTypes(node: GenericNode): string[] {
+  const types = (node.children ?? [])
+    .filter((child) => !SUPPLEMENTARY_HANDLED_CHILD_TYPES.has(child.type))
+    .map((child) => child.type);
+  return [...new Set(types)];
+}

--- a/packages/jats-convert/tests/convert.spec.ts
+++ b/packages/jats-convert/tests/convert.spec.ts
@@ -39,6 +39,7 @@ import preformatYml from './preformat.yml' with { type: 'text' };
 import referencesYml from './references.yml' with { type: 'text' };
 import tablesYml from './tables.yml' with { type: 'text' };
 import enumeratorsYml from './enumerators.yml' with { type: 'text' };
+import supplementaryYml from './supplementary.yml' with { type: 'text' };
 
 const YAML_FIXTURES: Record<string, string> = {
   'abstract-description.yml': abstractDescriptionYml,
@@ -51,6 +52,7 @@ const YAML_FIXTURES: Record<string, string> = {
   'preformat.yml': preformatYml,
   'references.yml': referencesYml,
   'tables.yml': tablesYml,
+  'supplementary.yml': supplementaryYml,
 };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/jats-convert/tests/supplementary.yml
+++ b/packages/jats-convert/tests/supplementary.yml
@@ -1,0 +1,112 @@
+cases:
+  - source: supplementary-multi-file
+    title: supplementary-material with multiple non-graphic media produces labeled download links
+    jats: |-
+      <sec sec-type="supplementary-material">
+        <title>Supporting information</title>
+        <supplementary-material id="DC2">
+          <label>Supplementary Information</label>
+          <media xlink:href="supplements/DC2/001370-1.pdf" mimetype="application" mime-subtype="pdf"/>
+          <media xlink:href="supplements/DC2/001370-2.xls" mimetype="application" mime-subtype="vnd.ms-excel"/>
+        </supplementary-material>
+      </sec>
+    mdast:
+      type: block
+      data:
+        part: supplementary-material
+      children:
+        - type: heading
+          children:
+            - type: text
+              value: Supporting information
+        - type: div
+          identifier: dc2
+          children:
+            - type: list
+              ordered: true
+              children:
+                - type: listItem
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: link
+                          url: supplements/DC2/001370-1.pdf
+                          static: true
+                          data:
+                            contentType: application/pdf
+                          children:
+                            - type: text
+                              value: Supplementary File 1 (pdf)
+                - type: listItem
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: link
+                          url: supplements/DC2/001370-2.xls
+                          static: true
+                          data:
+                            contentType: application/vnd.ms-excel
+                          children:
+                            - type: text
+                              value: Supplementary File 2 (xls)
+    expect_no_warn_contains:
+      - Supplementary-material rendered as generic content
+
+  - source: supplementary-single-file
+    title: single supplementary file uses a paragraph link
+    jats: |-
+      <supplementary-material id="S1">
+        <media xlink:href="supplements/data.csv" mimetype="text" mime-subtype="csv"/>
+      </supplementary-material>
+    mdast:
+      type: div
+      identifier: s1
+      children:
+        - type: paragraph
+          children:
+            - type: link
+              url: supplements/data.csv
+              static: true
+              data:
+                contentType: text/csv
+              children:
+                - type: text
+                  value: Supplementary File 1 (csv)
+
+  - source: supplementary-multi-figure
+    title: multiple supplementary figures are grouped in a div
+    jats: |-
+      <supplementary-material id="SF">
+        <media xlink:href="supplements/fig-s1.png" mimetype="image" mime-subtype="png"/>
+        <media xlink:href="supplements/fig-s2.png" mimetype="image" mime-subtype="png"/>
+      </supplementary-material>
+    mdast:
+      type: div
+      identifier: sf
+      children:
+        - type: container
+          kind: figure
+        - type: container
+          kind: figure
+    expect_no_warn_contains:
+      - Supplementary-material rendered as generic content
+
+  - source: supplementary-media-with-extra-children
+    title: warns when valid media is rendered but other child content is skipped
+    jats: |-
+      <supplementary-material id="DC2">
+        <label>Supplementary Information</label>
+        <media xlink:href="supplements/DC2/file.pdf" mimetype="application" mime-subtype="pdf"/>
+        <p>Extra description not rendered with media-only path.</p>
+      </supplementary-material>
+    mdast:
+      type: div
+      identifier: dc2
+      children:
+        - type: paragraph
+          children:
+            - type: link
+              url: supplements/DC2/file.pdf
+              static: true
+    expect_warn_contains:
+      - Supplementary-material has unhandled child content alongside media

--- a/packages/jats-convert/tests/supplementary.yml
+++ b/packages/jats-convert/tests/supplementary.yml
@@ -23,7 +23,6 @@ cases:
           identifier: dc2
           children:
             - type: list
-              ordered: true
               children:
                 - type: listItem
                   children:

--- a/packages/jats-convert/tests/supplementary.yml
+++ b/packages/jats-convert/tests/supplementary.yml
@@ -35,7 +35,7 @@ cases:
                             contentType: application/pdf
                           children:
                             - type: text
-                              value: Supplementary File 1 (pdf)
+                              value: Supplementary file (pdf)
                 - type: listItem
                   children:
                     - type: paragraph
@@ -47,7 +47,7 @@ cases:
                             contentType: application/vnd.ms-excel
                           children:
                             - type: text
-                              value: Supplementary File 2 (xls)
+                              value: Supplementary file (xls)
     expect_no_warn_contains:
       - Supplementary-material rendered as generic content
 
@@ -70,7 +70,7 @@ cases:
                 contentType: text/csv
               children:
                 - type: text
-                  value: Supplementary File 1 (csv)
+                  value: Supplementary file (csv)
 
   - source: supplementary-multi-figure
     title: multiple supplementary figures are grouped in a div
@@ -109,3 +109,55 @@ cases:
               static: true
     expect_warn_contains:
       - Supplementary-material has unhandled child content alongside media
+
+  - source: supplementary-labeled-siblings
+    title: sibling supplementary-material elements use their labels as link text
+    jats: |-
+      <sec sec-type="supplementary-material">
+        <title>Supporting information</title>
+        <supplementary-material>
+          <label>Supplemental figures and tables</label>
+          <media xlink:href="supplements/729924_file02.docx"/>
+        </supplementary-material>
+        <supplementary-material>
+          <label>Supplemental table 5</label>
+          <media xlink:href="supplements/729924_file03.xlsx"/>
+        </supplementary-material>
+        <supplementary-material>
+          <label>Supplemental table 6</label>
+          <media xlink:href="supplements/729924_file04.xlsx"/>
+        </supplementary-material>
+      </sec>
+    mdast:
+      type: block
+      data:
+        part: supplementary-material
+      children:
+        - type: heading
+          children:
+            - type: text
+              value: Supporting information
+        - type: paragraph
+          children:
+            - type: link
+              url: supplements/729924_file02.docx
+              static: true
+              children:
+                - type: text
+                  value: Supplemental figures and tables
+        - type: paragraph
+          children:
+            - type: link
+              url: supplements/729924_file03.xlsx
+              static: true
+              children:
+                - type: text
+                  value: Supplemental table 5
+        - type: paragraph
+          children:
+            - type: link
+              url: supplements/729924_file04.xlsx
+              static: true
+              children:
+                - type: text
+                  value: Supplemental table 6


### PR DESCRIPTION
Previously, if `supplemental-material` was an image, we identified this and rendered it as a figure. All other content under `supplementary-material` was just rendered using default renderers and raised a warning.

Now, we handle all `supplementary-material` files. Images still become figures, and other files become a list of links. Also, these files no longer raise a warning.

We still warn on other unknown structures in `supplementary-material`